### PR TITLE
Clarification of gflags channel

### DIFF
--- a/cpp/apidoc/Windows.md
+++ b/cpp/apidoc/Windows.md
@@ -44,6 +44,10 @@ Now, you can bootstrap a build environment
 conda create -n arrow-dev cmake git boost-cpp flatbuffers rapidjson cmake thrift-cpp snappy zlib brotli gflags lz4-c zstd -c conda-forge
 ```
 
+***Note:***
+> *Make sure to get the `conda-forge` build of `gflags` as the
+  naming of the library differs from that in the `defaults` channel*
+
 Activate just created conda environment with pre-installed packages from
 previous step:
 


### PR DESCRIPTION
Even though the instructions do show using the `conda-forge` channel, I always ignore that as I have `conda-forge` in my channel list by default so I never need to add that channel.

That's almost always fine because the builds are usually compatible. The fact that they're not is surprising so I think is worth an admonition.